### PR TITLE
Bold adjusted

### DIFF
--- a/packages/fhi-designsystem/src/theme/default.css
+++ b/packages/fhi-designsystem/src/theme/default.css
@@ -242,7 +242,7 @@
   --fhi-font-weight-light: 300;
   --fhi-font-weight-regular: 400;
   --fhi-font-weight-medium: 500;
-  --fhi-font-weight-bold: 700;
+  --fhi-font-weight-bold: 600;
 
   /**
   * @tokens PrimitiveFontSize


### PR DESCRIPTION
Justerer ned Bold for å ikke være så visuell tung, og i konteksten gi bedre flyt og lesbarhet. Det kunne vært justert mer møysommelig (f.eks. utnytte variable fonters mulighet til "625"), men det er noen restriksjoner i Figma sine variabler som begrenser oss veldig per nå (som er flagget i Figma-forumet).