### PR TITLE
 343-publish-package-to-npm-fails 

### DIFF
--- a/.github/workflows/docs-and-package.yaml
+++ b/.github/workflows/docs-and-package.yaml
@@ -63,8 +63,6 @@ jobs:
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org/'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Install dependencies
         if: steps.guard_job.outputs.should_run == 'true'


### PR DESCRIPTION
Pipelinen er satt som "Trusted Publisher" i NPM så token er ikke lenger nødvendig