### PR TITLE
Fix behaviour of input width

### DIFF
--- a/packages/fhi-designsystem/src/components/fhi-text-input/fhi-text-input.component.ts
+++ b/packages/fhi-designsystem/src/components/fhi-text-input/fhi-text-input.component.ts
@@ -357,6 +357,7 @@ export class FhiTextInput extends LitElement {
 
       input {
         box-sizing: border-box;
+        flex: 1 1 auto;
         height: var(--dimension-input-height);
         border: var(--dimension-input-border-width) solid
           var(--color-input-border);
@@ -416,7 +417,7 @@ export class FhiTextInput extends LitElement {
 
       .input-container {
         position: relative;
-        width: fit-content;
+        display: flex;
       }
 
       slot[name='start'] {


### PR DESCRIPTION
Dette fikser `fhi-text-input` til å virke som den gjorde før vi introduserte ikoner i felt. (Merk at `<fhi-text-input>` oppførsel aldri var 1 til 1 hvordan "vanilla"-HTMLs `<input>`, hvis man skulle teste.)

Test gjerne i forskjellige oppsett (les: `display: grid`, `flex`, osv.), inkl. i våre egne komponenter.

